### PR TITLE
just changed a little the pg_search config to make simpler

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,7 +5,10 @@ class SearchController < ApplicationController
   def index
     search_terms = params[:terms]
 
-    @movies = Movie.which_title_or_synopsis_contains(search_terms)
+    # The line below refers to the last pg_search config made by nephaest
+    # @movies = Movie.which_title_or_synopsis_contains(search_terms)
+    # The line below refers to the new config, less precise, but hopefully less ressource consuming as well
+    @movies = Movie.which_title_contains(search_terms)
     # @friends = current_user.friendslist
     @friends = current_user.get_friends_list
     render 'movies/index'

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -3,14 +3,25 @@ class Movie < ActiveRecord::Base
 
   pg_search_scope :autocomplete_title,
                   against: { fr_title: 'A', original_title: 'B', title: 'C' },
-                  associated_against: { people: :name },
+                  # associated_against: { people: :name },
                   ignoring: :accents,
                   using: { tsearch: { prefix: true, any_word: true } },
                   order_within_rank: "movies.imdb_score DESC"
 
-  pg_search_scope :which_title_or_synopsis_contains,
-                  against: { fr_title: 'A', original_title: 'B', title: 'C', fr_overview: 'D', overview: 'D', tagline: 'D' },
-                  associated_against: { people: :name },
+  # *** PREVIOUS PG_SEARCH CONFIG MADE BY NEPHAEST (BUT TOO RESSOURCE CONSUMING) ***
+  # pg_search_scope :which_title_or_synopsis_contains,
+  #                 against: { fr_title: 'A', original_title: 'B', title: 'C', fr_overview: 'D', overview: 'D', tagline: 'D' },
+  #                 associated_against: { people: :name },
+  #                 ignoring: :accents,
+  #                 using: {
+  #                           tsearch: { prefix: true },
+  #                           dmetaphone: { only: [:fr_title, :title, :origin_title] }
+  #                        },
+  #                 order_within_rank: "movies.imdb_score DESC"
+
+  pg_search_scope :which_title_contains,
+                  against: { fr_title: 'A', original_title: 'B', title: 'C' },
+                  # associated_against: { people: :name },
                   ignoring: :accents,
                   using: {
                             tsearch: { prefix: true },


### PR DESCRIPTION
Just changed the pg_search config: 
- for the proper search, I took off the columns "overview" and "tagline" (in both languages)
- i also deleted the association with people's name, for both the search and autocomplete.
